### PR TITLE
[S3] Manifiestos Kubernetes y Deploy por Entorno

### DIFF
--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -1,0 +1,60 @@
+name: Deploy Environments
+
+on:
+    push:
+        branches:
+            - main
+            - develop
+    workflow_dispatch:
+
+jobs:
+    deploy_dev:
+        runs-on: ubuntu-latest
+
+        env:
+            KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v4
+
+            -   name: Configure kubectl
+                run: |
+                    mkdir -p ~/.kube
+                    echo "${KUBE_CONFIG}" > ~/.kube/config
+                    chmod 600 ~/.kube/config
+                    kubectl config get-contexts || true
+
+            -   name: Apply Kubernetes manifests (dev)
+                run: |
+                    kubectl apply -f k8s/namespace-dev.yml
+                    kubectl apply -f k8s/configmap-dev.yml
+                    kubectl apply -f k8s/deployment-dev.yml
+                    kubectl apply -f k8s/service-dev.yml
+
+    deploy_staging:
+        runs-on: ubuntu-latest
+        needs: deploy_dev
+        environment:
+            name: staging
+
+        env:
+            KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+
+        steps:
+            -   name: Checkout repository
+                uses: actions/checkout@v4
+
+            -   name: Configure kubectl
+                run: |
+                    mkdir -p ~/.kube
+                    echo "${KUBE_CONFIG}" > ~/.kube/config
+                    chmod 600 ~/.kube/config
+                    kubectl config get-contexts || true
+
+            -   name: Apply Kubernetes manifests (staging)
+                run: |
+                    kubectl apply -f k8s/namespace-staging.yml
+                    kubectl apply -f k8s/configmap-staging.yml
+                    kubectl apply -f k8s/deployment-staging.yml
+                    kubectl apply -f k8s/service-staging.yml

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -27,10 +27,29 @@ jobs:
 
             -   name: Apply Kubernetes manifests (dev)
                 run: |
-                    kubectl apply -f k8s/namespace-dev.yml
-                    kubectl apply -f k8s/configmap-dev.yml
-                    kubectl apply -f k8s/deployment-dev.yml
-                    kubectl apply -f k8s/service-dev.yml
+                    mkdir -p .evidence
+                    set -o pipefail
+                    echo "=== Deploy Dev ===" | tee .evidence/deploy-dev.log
+                    date -u | tee -a .evidence/deploy-dev.log
+
+                    echo "--- kubectl apply k8s/namespace-dev.yml ---" | tee -a .evidence/deploy-dev.log
+                    kubectl apply -f k8s/namespace-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+
+                    echo "--- kubectl apply k8s/configmap-dev.yml ---" | tee -a .evidence/deploy-dev.log
+                    kubectl apply -f k8s/configmap-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+
+                    echo "--- kubectl apply k8s/deployment-dev.yml ---" | tee -a .evidence/deploy-dev.log
+                    kubectl apply -f k8s/deployment-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+
+                    echo "--- kubectl apply k8s/service-dev.yml ---" | tee -a .evidence/deploy-dev.log
+                    kubectl apply -f k8s/service-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+
+            -   name: Upload deployment evidence (dev)
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: deploy-dev-evidence
+                    path: .evidence/deploy-dev.log
 
     deploy_staging:
         runs-on: ubuntu-latest
@@ -54,7 +73,26 @@ jobs:
 
             -   name: Apply Kubernetes manifests (staging)
                 run: |
-                    kubectl apply -f k8s/namespace-staging.yml
-                    kubectl apply -f k8s/configmap-staging.yml
-                    kubectl apply -f k8s/deployment-staging.yml
-                    kubectl apply -f k8s/service-staging.yml
+                    mkdir -p .evidence
+                    set -o pipefail
+                    echo "=== Deploy Staging ===" | tee .evidence/deploy-staging.log
+                    date -u | tee -a .evidence/deploy-staging.log
+
+                    echo "--- kubectl apply k8s/namespace-staging.yml ---" | tee -a .evidence/deploy-staging.log
+                    kubectl apply -f k8s/namespace-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+
+                    echo "--- kubectl apply k8s/configmap-staging.yml ---" | tee -a .evidence/deploy-staging.log
+                    kubectl apply -f k8s/configmap-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+
+                    echo "--- kubectl apply k8s/deployment-staging.yml ---" | tee -a .evidence/deploy-staging.log
+                    kubectl apply -f k8s/deployment-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+
+                    echo "--- kubectl apply k8s/service-staging.yml ---" | tee -a .evidence/deploy-staging.log
+                    kubectl apply -f k8s/service-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+
+            -   name: Upload deployment evidence (staging)
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                    name: deploy-staging-evidence
+                    path: .evidence/deploy-staging.log

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -5,6 +5,7 @@ on:
         branches:
             - main
             - develop
+            - feature/sandro-deploy_env
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -27,29 +27,29 @@ jobs:
 
             -   name: Apply Kubernetes manifests (dev)
                 run: |
-                    mkdir -p .evidence
+                    mkdir -p evidence
                     set -o pipefail
-                    echo "=== Deploy Dev ===" | tee .evidence/deploy-dev.log
-                    date -u | tee -a .evidence/deploy-dev.log
+                    echo "=== Deploy Dev ===" | tee evidence/deploy-dev.log
+                    date -u | tee -a evidence/deploy-dev.log
 
-                    echo "--- kubectl apply k8s/namespace-dev.yml ---" | tee -a .evidence/deploy-dev.log
-                    kubectl apply -f k8s/namespace-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+                    echo "--- kubectl apply k8s/namespace-dev.yml ---" | tee -a evidence/deploy-dev.log
+                    kubectl apply -f k8s/namespace-dev.yml 2>&1 | tee -a evidence/deploy-dev.log
 
-                    echo "--- kubectl apply k8s/configmap-dev.yml ---" | tee -a .evidence/deploy-dev.log
-                    kubectl apply -f k8s/configmap-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+                    echo "--- kubectl apply k8s/configmap-dev.yml ---" | tee -a evidence/deploy-dev.log
+                    kubectl apply -f k8s/configmap-dev.yml 2>&1 | tee -a evidence/deploy-dev.log
 
-                    echo "--- kubectl apply k8s/deployment-dev.yml ---" | tee -a .evidence/deploy-dev.log
-                    kubectl apply -f k8s/deployment-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+                    echo "--- kubectl apply k8s/deployment-dev.yml ---" | tee -a evidence/deploy-dev.log
+                    kubectl apply -f k8s/deployment-dev.yml 2>&1 | tee -a evidence/deploy-dev.log
 
-                    echo "--- kubectl apply k8s/service-dev.yml ---" | tee -a .evidence/deploy-dev.log
-                    kubectl apply -f k8s/service-dev.yml 2>&1 | tee -a .evidence/deploy-dev.log
+                    echo "--- kubectl apply k8s/service-dev.yml ---" | tee -a evidence/deploy-dev.log
+                    kubectl apply -f k8s/service-dev.yml 2>&1 | tee -a evidence/deploy-dev.log
 
             -   name: Upload deployment evidence (dev)
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
                     name: deploy-dev-evidence
-                    path: .evidence/deploy-dev.log
+                    path: evidence/deploy-dev.log
 
     deploy_staging:
         runs-on: ubuntu-latest
@@ -73,26 +73,26 @@ jobs:
 
             -   name: Apply Kubernetes manifests (staging)
                 run: |
-                    mkdir -p .evidence
+                    mkdir -p evidence
                     set -o pipefail
-                    echo "=== Deploy Staging ===" | tee .evidence/deploy-staging.log
-                    date -u | tee -a .evidence/deploy-staging.log
+                    echo "=== Deploy Staging ===" | tee evidence/deploy-staging.log
+                    date -u | tee -a evidence/deploy-staging.log
 
-                    echo "--- kubectl apply k8s/namespace-staging.yml ---" | tee -a .evidence/deploy-staging.log
-                    kubectl apply -f k8s/namespace-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+                    echo "--- kubectl apply k8s/namespace-staging.yml ---" | tee -a evidence/deploy-staging.log
+                    kubectl apply -f k8s/namespace-staging.yml 2>&1 | tee -a evidence/deploy-staging.log
 
-                    echo "--- kubectl apply k8s/configmap-staging.yml ---" | tee -a .evidence/deploy-staging.log
-                    kubectl apply -f k8s/configmap-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+                    echo "--- kubectl apply k8s/configmap-staging.yml ---" | tee -a evidence/deploy-staging.log
+                    kubectl apply -f k8s/configmap-staging.yml 2>&1 | tee -a evidence/deploy-staging.log
 
-                    echo "--- kubectl apply k8s/deployment-staging.yml ---" | tee -a .evidence/deploy-staging.log
-                    kubectl apply -f k8s/deployment-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+                    echo "--- kubectl apply k8s/deployment-staging.yml ---" | tee -a evidence/deploy-staging.log
+                    kubectl apply -f k8s/deployment-staging.yml 2>&1 | tee -a evidence/deploy-staging.log
 
-                    echo "--- kubectl apply k8s/service-staging.yml ---" | tee -a .evidence/deploy-staging.log
-                    kubectl apply -f k8s/service-staging.yml 2>&1 | tee -a .evidence/deploy-staging.log
+                    echo "--- kubectl apply k8s/service-staging.yml ---" | tee -a evidence/deploy-staging.log
+                    kubectl apply -f k8s/service-staging.yml 2>&1 | tee -a evidence/deploy-staging.log
 
             -   name: Upload deployment evidence (staging)
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
                     name: deploy-staging-evidence
-                    path: .evidence/deploy-staging.log
+                    path: evidence/deploy-staging.log

--- a/.github/workflows/deploy_env.yml
+++ b/.github/workflows/deploy_env.yml
@@ -5,7 +5,6 @@ on:
         branches:
             - main
             - develop
-            - feature/sandro-deploy_env
     workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -408,3 +408,52 @@ Los Services exponen los Pods mediante NodePort:
 |---------|---------|----------------|----------|
 | Dev | `featureflags-service-dev` | 8000 | 30000 |
 | Staging | `featureflags-service-staging` | 8001 | 30001 |
+
+
+## **Automatización de Despliegue en Kubernetes**
+
+Incluye un pipeline de despliegue automatizado para aplicar los manifiestos de Kubernetes por entorno utilizando `kubectl` desde GitHub Actions.
+
+### **Workflow: `.github/workflows/deploy_env.yml`**
+
+El pipeline define dos jobs:
+
+#### **1. `deploy_dev` — Despliegue automático**
+
+* Se ejecuta en cada **push a `main` o `develop`**.
+* Aplica los manifests del entorno de desarrollo:
+
+  ```
+  k8s/namespace-dev.yml
+  k8s/configmap-dev.yml
+  k8s/deployment-dev.yml
+  k8s/service-dev.yml
+  ```
+* Prepara la estructura completa del entorno `featureflags-dev`.
+
+#### **2. `deploy_staging` — Despliegue con aprobación**
+
+* Requiere aprobación manual en el **Environment `staging`** antes de ejecutarse.
+* Aplica los manifests del entorno de staging:
+
+  ```
+  k8s/namespace-staging.yml
+  k8s/configmap-staging.yml
+  k8s/deployment-staging.yml
+  k8s/service-staging.yml
+  ```
+* Simula un control de cambios seguro y una promoción manual entre entornos.
+
+### **Requisitos**
+
+* El pipeline está preparado para usar un secreto `KUBE_CONFIG` que contenga la configuración del cluster Kubernetes.
+* Si no se configura un cluster real, los comandos `kubectl apply` fallarán, pero la estructura del workflow sigue siendo válida y completa para fines del proyecto.
+
+### **Evidencias**
+
+El workflow genera archivos de evidencia con los comandos y resultados de los despliegues:
+
+```
+.evidence/deploy-dev.log
+.evidence/deploy-staging.log
+```

--- a/k8s/configmap-dev.yml
+++ b/k8s/configmap-dev.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: featureflags-config-dev
+  namespace: featureflags-dev
+data:
+  ENVIRONMENT: "dev"
+  DEFAULT_FLAG_STRATEGY: "permissive"
+  LOG_LEVEL: "DEBUG"
+  API_PORT: "8000"
+  DATABASE_URL: "sqlite:///./data/featureflags_dev.db"

--- a/k8s/configmap-staging.yml
+++ b/k8s/configmap-staging.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: featureflags-config-staging
+  namespace: featureflags-staging
+data:
+  ENVIRONMENT: "staging"
+  DEFAULT_FLAG_STRATEGY: "conservative"
+  LOG_LEVEL: "INFO"
+  API_PORT: "8001"
+  DATABASE_URL: "sqlite:///./data/featureflags_staging.db"

--- a/k8s/deployment-dev.yml
+++ b/k8s/deployment-dev.yml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: featureflags-api-dev
+  namespace: featureflags-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureflags-api
+      tier: backend
+      stage: dev
+  template:
+    metadata:
+      labels:
+        app: featureflags-api
+        tier: backend
+        stage: dev
+    spec:
+      containers:
+        - name: featureflags-api
+          image: featureflags-api:dev
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: featureflags-config-dev
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: data-volume
+              mountPath: /app/data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+      volumes:
+        - name: data-volume
+          emptyDir: {}

--- a/k8s/deployment-staging.yml
+++ b/k8s/deployment-staging.yml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: featureflags-api-staging
+  namespace: featureflags-staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: featureflags-api
+      tier: backend
+      stage: staging
+  template:
+    metadata:
+      labels:
+        app: featureflags-api
+        tier: backend
+        stage: staging
+    spec:
+      containers:
+        - name: featureflags-api
+          image: featureflags-api:staging
+          imagePullPolicy: IfNotPresent
+          envFrom:
+            - configMapRef:
+                name: featureflags-config-staging
+          ports:
+            - containerPort: 8000
+          volumeMounts:
+            - name: data-volume
+              mountPath: /app/data
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+      volumes:
+        - name: data-volume
+          emptyDir: {}

--- a/k8s/namespace-dev.yml
+++ b/k8s/namespace-dev.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: featureflags-dev
+  labels:
+    name: featureflags-dev
+    environment: dev
+    managed-by: feature-flags-team

--- a/k8s/namespace-staging.yml
+++ b/k8s/namespace-staging.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: featureflags-staging
+  labels:
+    name: featureflags-staging
+    environment: staging
+    managed-by: feature-flags-team

--- a/k8s/service-dev.yml
+++ b/k8s/service-dev.yml
@@ -8,8 +8,9 @@ metadata:
     environment: dev
 spec:
   ports:
-  - port: 80
+  - port: 8000
     targetPort: 8000
+    nodePort: 30000
     protocol: TCP
     name: http
   selector:

--- a/k8s/service-dev.yml
+++ b/k8s/service-dev.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: featureflags-api-service
+  namespace: featureflags-dev
+  labels:
+    app: featureflags-hub
+    environment: dev
+spec:
+  ports:
+  - port: 80
+    targetPort: 8000
+    protocol: TCP
+    name: http
+  selector:
+    app: featureflags-hub
+    environment: dev

--- a/k8s/service-staging.yml
+++ b/k8s/service-staging.yml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: featureflags-api-service
+  namespace: featureflags-staging
+  labels:
+    app: featureflags-hub
+    environment: staging
+spec:
+  ports:
+  - port: 80
+    targetPort: 8000
+    protocol: TCP
+    name: http
+  selector:
+    app: featureflags-hub
+    environment: staging

--- a/k8s/service-staging.yml
+++ b/k8s/service-staging.yml
@@ -8,8 +8,9 @@ metadata:
     environment: staging
 spec:
   ports:
-  - port: 80
+  - port: 8001
     targetPort: 8000
+    nodePort: 30001
     protocol: TCP
     name: http
   selector:

--- a/videos.txt
+++ b/videos.txt
@@ -1,0 +1,1 @@
+https://drive.google.com/drive/folders/16UzCghObxrUUHTzlIQ8dl6sqL5r-kpSW?usp=sharing


### PR DESCRIPTION
# Manifiestos Kubernetes y Deploy por Entorno

## Descripción
Se incorporan manifiestos Kubernetes para dev y staging y un workflow de deploy por entorno con evidencias, cumpliendo el Sprint 3.

## Cambios
- k8s/namespaces:
  - namespace-dev.yml
  - namespace-staging.yml
- k8s/configuración (ConfigMaps):
  - configmap-dev.yml (ENVIRONMENT=dev, DEFAULT_FLAG_STRATEGY=permissive, LOG_LEVEL=DEBUG, API_PORT=8000, DATABASE_URL sqlite dev)
  - configmap-staging.yml (ENVIRONMENT=staging, DEFAULT_FLAG_STRATEGY=conservative, LOG_LEVEL=INFO, API_PORT=8001, DATABASE_URL sqlite staging)
- k8s/despliegue (Deployments):
  - deployment-dev.yml (imagen featureflags-api:dev, envFrom ConfigMap, labels app/tier/stage)
  - deployment-staging.yml (imagen featureflags-api:staging, envFrom ConfigMap, labels app/tier/stage)
- k8s/servicios (exposición):
  - service-dev.yml (NodePort 30000 → targetPort 8000)
  - service-staging.yml (NodePort 30001 → targetPort 8000, service port 8001)
- CI/CD:
  - deploy_env.yml
    - deploy_dev: aplica manifests en featureflags-dev en push/dispatch
    - deploy_staging: requiere Environment “staging” (approval), aplica manifests
    - evidencia: evidencia/deploy-dev.log y evidencia/deploy-staging.log como artifacts